### PR TITLE
Add Flux (alt) implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,16 @@ Run the watchers, dev and source maps servers for the real production build:
 $ npm run prod
 ```
 
-Run the watchers and the Webpack dev server w/ React hot loader:
+Run the watchers and the Webpack dev server:
 
 ```
 $ npm run dev
+```
+
+Run the watchers and the Webpack dev server w/ React hot loader:
+
+```
+$ npm run hot
 ```
 
 URLS to test things out:

--- a/client/actions/convert.js
+++ b/client/actions/convert.js
@@ -1,0 +1,14 @@
+/**
+ * Actions: Convert
+ */
+import alt from "../alt";
+
+class ConvertActions {
+  constructor() {
+    this.generateActions(
+      "fetchConversions"
+    );
+  }
+}
+
+export default alt.createActions(ConvertActions);

--- a/client/actions/convert.js
+++ b/client/actions/convert.js
@@ -6,7 +6,8 @@ import alt from "../alt";
 class ConvertActions {
   constructor() {
     this.generateActions(
-      "fetchConversions"
+      "fetchConversions",
+      "setConversionTypes"
     );
   }
 }

--- a/client/actions/convert.js
+++ b/client/actions/convert.js
@@ -7,7 +7,8 @@ class ConvertActions {
   constructor() {
     this.generateActions(
       "fetchConversions",
-      "setConversionTypes"
+      "setConversionTypes",
+      "setConversionValue"
     );
   }
 }

--- a/client/alt.js
+++ b/client/alt.js
@@ -1,0 +1,6 @@
+/**
+ * Alt instance.
+ */
+import Alt from "alt";
+
+export default new Alt();

--- a/client/components/convert.jsx
+++ b/client/components/convert.jsx
@@ -7,7 +7,7 @@ import ConvertActions from "../actions/convert";
 
 export default class Convert extends React.Component {
   onClick() {
-    ConvertActions.fetchConversions(["camel"]); // TODO: Real values.
+    ConvertActions.fetchConversions();
   }
 
   render() {

--- a/client/components/convert.jsx
+++ b/client/components/convert.jsx
@@ -3,12 +3,17 @@
  */
 import React from "react";
 import Button from "react-bootstrap/lib/Button";
+import ConvertActions from "../actions/convert";
 
 export default class Convert extends React.Component {
+  onClick() {
+    ConvertActions.fetchConversions(["camel"]); // TODO: Real values.
+  }
+
   render() {
     return (
       <span className="input-group-btn">
-        <Button>
+        <Button onClick={this.onClick.bind(this)}>
           Convert
         </Button>
       </span>

--- a/client/components/input.jsx
+++ b/client/components/input.jsx
@@ -4,11 +4,18 @@
 import React from "react";
 import Input from "react-bootstrap/lib/Input";
 
+import ConvertActions from "../actions/convert";
+
 export default class UserInput extends React.Component {
+  onChange(ev) {
+    ConvertActions.setConversionValue(ev.target.value);
+  }
+
   render() {
     return (
       <Input
         className="form-control"
+        onChange={this.onChange.bind(this)}
         placeholder="Text to convert..."
         type="text"
       />

--- a/client/components/input.jsx
+++ b/client/components/input.jsx
@@ -11,11 +11,18 @@ export default class UserInput extends React.Component {
     ConvertActions.setConversionValue(ev.target.value);
   }
 
+  onKeyDown(ev) {
+    if (ev.which === 13 /* Enter key */) {
+      ConvertActions.fetchConversions();
+    }
+  }
+
   render() {
     return (
       <Input
         className="form-control"
-        onChange={this.onChange.bind(this)}
+        onChange={this.onChange}
+        onKeyDown={this.onKeyDown}
         placeholder="Text to convert..."
         type="text"
       />

--- a/client/components/output-panel.jsx
+++ b/client/components/output-panel.jsx
@@ -1,0 +1,23 @@
+/**
+ * Convert output panel
+ */
+import React from "react";
+import Panel from "react-bootstrap/lib/Panel";
+
+export default class OutputPanel extends React.Component {
+  render() {
+    return (
+      <Panel
+        className="output-panel"
+        header=<h3>{this.props.title}</h3>
+        >
+        {this.props.content}
+      </Panel>
+    );
+  }
+}
+
+OutputPanel.propTypes = {
+  content: React.PropTypes.string,
+  title: React.PropTypes.string
+};

--- a/client/components/output.jsx
+++ b/client/components/output.jsx
@@ -1,0 +1,38 @@
+/**
+ * Convert output.
+ */
+import React from "react";
+import OutputPanel from "./output-panel";
+import ConvertStore from "../stores/convert";
+
+export default class Output extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = ConvertStore.getState();
+
+    // TODO: Get auto-binding or descriptor thingy.
+    this.onChange = this.onChange.bind(this);
+  }
+
+  componentDidMount() {
+    ConvertStore.listen(this.onChange);
+  }
+
+  componentWillUnmount() {
+    ConvertStore.unlisten(this.onChange);
+  }
+
+  onChange() {
+    this.setState(ConvertStore.getState());
+  }
+
+  render() {
+    return (
+      <div>
+        {this.state.conversions.map(conv =>
+          <OutputPanel {...conv} key={conv.title} />
+        )}
+      </div>
+    );
+  }
+}

--- a/client/components/page.jsx
+++ b/client/components/page.jsx
@@ -7,6 +7,7 @@ import Jumbotron from "react-bootstrap/lib/Jumbotron";
 import Convert from "./convert";
 import Input from "./input";
 import Types from "./types";
+import Output from "./output";
 
 export default class Page extends React.Component {
    render() {
@@ -21,6 +22,7 @@ export default class Page extends React.Component {
           <Input />
           <Types />
         </div>
+        <Output />
       </div>
     );
   };

--- a/client/components/types.jsx
+++ b/client/components/types.jsx
@@ -6,24 +6,27 @@ import DropdownButton from "react-bootstrap/lib/DropdownButton";
 import MenuItem from "react-bootstrap/lib/MenuItem";
 
 import Title from "./types-title";
+import types from "../utils/types";
 
 export default class Types extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { title: Types._TYPES.camel };
+  getStoreState() {
+    return { title: "camel" };
   }
 
-  _setType(key) {
-    const title = Types._TYPES[key] ||
-      (key === Types._ALL ? Types._ALL_DESC : undefined);
+  constructor(props) {
+    super(props);
+    this.state = this.getStoreState();
+  }
+
+  setType(key) {
+    const title = types.getTitle(key);
     this.setState({ title: title });
   }
 
   render() {
-    const types = Types._TYPES;
-    const items = Object.keys(types).map(key => (
-      <MenuItem key={key} onClick={this._setType.bind(this, key)}>
-        {types[key]}
+    const items = Object.keys(types.TYPES).map(key => (
+      <MenuItem key={key} onClick={this.setType.bind(this, key)}>
+        {types.getTitle(key)}
       </MenuItem>
     ));
 
@@ -35,21 +38,10 @@ export default class Types extends React.Component {
         >
         {items}
         <MenuItem divider />
-        <MenuItem onClick={this._setType.bind(this, Types._ALL)}>
-          <strong>{Types._ALL_DESC}</strong>
+        <MenuItem onClick={this.setType.bind(this, types.ALL)}>
+          <strong>{types.ALL_DESC}</strong>
         </MenuItem>
       </DropdownButton>
     );
   }
 }
-
-// All the individual types.
-Types._TYPES = {
-  camel: "camel case",
-  snake: "snake case",
-  dash: "dasherized"
-};
-
-// Special case "all types".
-Types._ALL = Object.keys(Types._TYPES);
-Types._ALL_DESC = "all the things";

--- a/client/components/types.jsx
+++ b/client/components/types.jsx
@@ -11,6 +11,8 @@ import types from "../utils/types";
 import ConvertActions from "../actions/convert";
 import ConvertStore from "../stores/convert";
 
+const noop = function () {};
+
 export default class Types extends React.Component {
   constructor(props) {
     super(props);
@@ -46,6 +48,9 @@ export default class Types extends React.Component {
     return (
       <DropdownButton
         className="input-group-btn"
+        // BUG: Dropdowns don't close by default. Here's a patch.
+        // See: https://github.com/react-bootstrap/react-bootstrap/pull/195
+        onSelect={noop}
         pullRight
         title=<Title title={types.getTitle(this.state.types)} />
         >

--- a/client/components/types.jsx
+++ b/client/components/types.jsx
@@ -8,25 +8,38 @@ import MenuItem from "react-bootstrap/lib/MenuItem";
 import Title from "./types-title";
 import types from "../utils/types";
 
-export default class Types extends React.Component {
-  getStoreState() {
-    return { title: "camel" };
-  }
+import ConvertActions from "../actions/convert";
+import ConvertStore from "../stores/convert";
 
+export default class Types extends React.Component {
   constructor(props) {
     super(props);
-    this.state = this.getStoreState();
+    this.state = ConvertStore.getState();
+
+    // TODO: Get auto-binding or descriptor thingy.
+    this.onChange = this.onChange.bind(this);
   }
 
-  setType(key) {
-    const title = types.getTitle(key);
-    this.setState({ title: title });
+  componentDidMount() {
+    ConvertStore.listen(this.onChange);
+  }
+
+  componentWillUnmount() {
+    ConvertStore.unlisten(this.onChange);
+  }
+
+  onChange() {
+    this.setState(ConvertStore.getState());
+  }
+
+  setTypes(conversionTypes) {
+    ConvertActions.setConversionTypes(conversionTypes);
   }
 
   render() {
-    const items = Object.keys(types.TYPES).map(key => (
-      <MenuItem key={key} onClick={this.setType.bind(this, key)}>
-        {types.getTitle(key)}
+    const items = Object.keys(types.TYPES).map(type => (
+      <MenuItem key={type} onClick={this.setTypes.bind(this, type)}>
+        {types.getTitle(type)}
       </MenuItem>
     ));
 
@@ -34,11 +47,11 @@ export default class Types extends React.Component {
       <DropdownButton
         className="input-group-btn"
         pullRight
-        title=<Title title={this.state.title} />
+        title=<Title title={types.getTitle(this.state.types)} />
         >
         {items}
         <MenuItem divider />
-        <MenuItem onClick={this.setType.bind(this, types.ALL)}>
+        <MenuItem onClick={this.setTypes.bind(this, types.ALL)}>
           <strong>{types.ALL_DESC}</strong>
         </MenuItem>
       </DropdownButton>

--- a/client/components/types.jsx
+++ b/client/components/types.jsx
@@ -10,34 +10,46 @@ import Title from "./types-title";
 export default class Types extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { title: undefined };
+    this.state = { title: Types._TYPES.camel };
   }
 
-  _setType(type) {
-    this.setState({ title: type });
+  _setType(key) {
+    const title = Types._TYPES[key] ||
+      (key === Types._ALL ? Types._ALL_DESC : undefined);
+    this.setState({ title: title });
   }
 
   render() {
+    const types = Types._TYPES;
+    const items = Object.keys(types).map(key => (
+      <MenuItem key={key} onClick={this._setType.bind(this, key)}>
+        {types[key]}
+      </MenuItem>
+    ));
+
     return (
       <DropdownButton
         className="input-group-btn"
         pullRight
         title=<Title title={this.state.title} />
         >
-        <MenuItem onClick={this._setType.bind(this, "camel case")}>
-          camel case
-        </MenuItem>
-        <MenuItem onClick={this._setType.bind(this, "snake case")}>
-          snake case
-        </MenuItem>
-        <MenuItem onClick={this._setType.bind(this, "dasherized")}>
-          dasherized
-        </MenuItem>
+        {items}
         <MenuItem divider />
-        <MenuItem onClick={this._setType.bind(this, "all the things")}>
-          <strong>all the things</strong>
+        <MenuItem onClick={this._setType.bind(this, Types._ALL)}>
+          <strong>{Types._ALL_DESC}</strong>
         </MenuItem>
       </DropdownButton>
     );
   }
 }
+
+// All the individual types.
+Types._TYPES = {
+  camel: "camel case",
+  snake: "snake case",
+  dash: "dasherized"
+};
+
+// Special case "all types".
+Types._ALL = Object.keys(Types._TYPES);
+Types._ALL_DESC = "all the things";

--- a/client/stores/convert.js
+++ b/client/stores/convert.js
@@ -15,18 +15,23 @@ class ConvertStore {
     // TODO: Switch to immutable-js + alt integration.
     this.conversions = [];
     this.types = types.DEFAULT_TYPE;
+    this.value = "";
   }
 
   onFetchConversions(/*conversions*/) {
     // TODO: IMPLEMENT
     this.conversions = this.types.split(",").map(type => ({
       title: type,
-      content: "TODO " + type
+      content: "TODO " + this.value
     }));
   }
 
   onSetConversionTypes(conversionTypes) {
     this.types = conversionTypes;
+  }
+
+  onSetConversionValue(value) {
+    this.value = value;
   }
 }
 

--- a/client/stores/convert.js
+++ b/client/stores/convert.js
@@ -12,13 +12,19 @@ class ConvertStore {
 
     // TODO: Switch to immutable-js + alt integration.
     this.conversions = [];
+    this.types = ["camel"];
   }
 
   onFetchConversions(/*conversions*/) {
+    // TODO: IMPLEMENT
     this.conversions = [{
       title: "camel",
       content: "todo"
     }];
+  }
+
+  onSetConversionTypes(types) {
+    this.types = types;
   }
 }
 

--- a/client/stores/convert.js
+++ b/client/stores/convert.js
@@ -4,6 +4,8 @@
 import alt from "../alt";
 import ConvertActions from "../actions/convert";
 
+import types from "../utils/types";
+
 class ConvertStore {
   constructor() {
     // Auto-magically bind to methods with `onACTION` or `ACTION`.
@@ -12,19 +14,19 @@ class ConvertStore {
 
     // TODO: Switch to immutable-js + alt integration.
     this.conversions = [];
-    this.types = ["camel"];
+    this.types = types.DEFAULT_TYPE;
   }
 
   onFetchConversions(/*conversions*/) {
     // TODO: IMPLEMENT
-    this.conversions = [{
-      title: "camel",
-      content: "todo"
-    }];
+    this.conversions = this.types.split(",").map(type => ({
+      title: type,
+      content: "TODO " + type
+    }));
   }
 
-  onSetConversionTypes(types) {
-    this.types = types;
+  onSetConversionTypes(conversionTypes) {
+    this.types = conversionTypes;
   }
 }
 

--- a/client/stores/convert.js
+++ b/client/stores/convert.js
@@ -20,6 +20,7 @@ class ConvertStore {
 
   onFetchConversions(/*conversions*/) {
     // TODO: IMPLEMENT
+    // TODO: Add error state and UI + test out.
     this.conversions = this.types.split(",").map(type => ({
       title: type,
       content: "TODO " + this.value

--- a/client/stores/convert.js
+++ b/client/stores/convert.js
@@ -1,0 +1,25 @@
+/**
+ * Stores: Convert
+ */
+import alt from "../alt";
+import ConvertActions from "../actions/convert";
+
+class ConvertStore {
+  constructor() {
+    // Auto-magically bind to methods with `onACTION` or `ACTION`.
+    // See: http://alt.js.org/docs/createStore/#storemodelbindactions
+    this.bindActions(ConvertActions);
+
+    // TODO: Switch to immutable-js + alt integration.
+    this.conversions = [];
+  }
+
+  onFetchConversions(/*conversions*/) {
+    this.conversions = [{
+      title: "camel",
+      content: "todo"
+    }];
+  }
+}
+
+export default alt.createStore(ConvertStore);

--- a/client/utils/types.js
+++ b/client/utils/types.js
@@ -1,0 +1,22 @@
+/**
+ * Enums / values for "types".
+ */
+// All the individual types.
+let types = {
+  TYPES: {
+    camel: "camel case",
+    snake: "snake case",
+    dash: "dasherized"
+  },
+
+  getTitle: function (key) {
+    return types.TYPES[key] ||
+      (key === types.ALL ? types.ALL_DESC : undefined);
+  }
+};
+
+// Special case "all types".
+types.ALL = Object.keys(types.TYPES);
+types.ALL_DESC = "all the things";
+
+export default types;

--- a/client/utils/types.js
+++ b/client/utils/types.js
@@ -9,14 +9,20 @@ let types = {
     dash: "dasherized"
   },
 
-  getTitle: function (key) {
-    return types.TYPES[key] ||
-      (key === types.ALL ? types.ALL_DESC : undefined);
+  /**
+   * Get title from array of type keys.
+   *
+   * @param   {String} type conversion type (e.g., "camel")
+   * @returns {String}      UI-friendly title
+   */
+  getTitle: function (type) {
+    return types.TYPES[type] ||
+      (type === types.ALL ? types.ALL_DESC : undefined);
   }
 };
 
 // Special case "all types".
-types.ALL = Object.keys(types.TYPES);
+types.ALL = Object.keys(types.TYPES).join(",");
 types.ALL_DESC = "all the things";
 
 export default types;

--- a/client/utils/types.js
+++ b/client/utils/types.js
@@ -3,6 +3,8 @@
  */
 // All the individual types.
 let types = {
+  DEFAULT_TYPE: "camel",
+
   TYPES: {
     camel: "camel case",
     snake: "snake case",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "test": "npm run lint",
     "start": "node server/index.js",
     "server": "nodemon --watch client --watch server server/index.js",
+    "server-dev": "webpack-dev-server --config webpack.config.dev.js --progress --colors --port 2992",
     "server-hot": "webpack-dev-server --config webpack.config.hot.js --hot --progress --colors --port 2992 --inline",
     "sources": "http-server -p 3001 .",
     "watch": "webpack --watch",
     "prod": "npm run watch & npm run server & npm run sources",
-    "dev": "npm run server-hot & WEBPACK_HOT=true npm run server",
+    "dev": "npm run server-dev & WEBPACK_DEV=true npm run server",
+    "hot": "npm run server-hot & WEBPACK_DEV=true npm run server",
     "build": "webpack"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/FormidableLabs/converter-react",
   "dependencies": {
+    "alt": "^0.16.2",
     "babel": "^5.1.13",
     "babel-core": "^5.1.13",
     "babel-loader": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "npm run lint-server && npm run lint-client",
     "test": "npm run lint",
     "start": "node server/index.js",
-    "server": "nodemon --watch client --watch server server/index.js",
+    "server": "nodemon --watch client --watch server --ext js,jsx server/index.js",
     "server-dev": "webpack-dev-server --config webpack.config.dev.js --progress --colors --port 2992",
     "server-hot": "webpack-dev-server --config webpack.config.hot.js --hot --progress --colors --port 2992 --inline",
     "sources": "http-server -p 3001 .",

--- a/server/index.js
+++ b/server/index.js
@@ -13,7 +13,7 @@ var app = module.exports = express();
 var converter = require("./converter");
 
 var PORT = process.env.PORT || 3000;
-var IS_HOT = process.env.WEBPACK_HOT === "true";
+var WEBPACK_DEV = process.env.WEBPACK_DEV === "true";
 var RENDER_JS = true;
 var RENDER_SS = true;
 
@@ -59,8 +59,8 @@ app.use("/", function (req, res) {
   var bundleJs;
 
   if (renderJs) {
-    if (IS_HOT) {
-      bundleJs = "http://127.0.0.1:2992/js/bundle.hot.js";
+    if (WEBPACK_DEV) {
+      bundleJs = "http://127.0.0.1:2992/js/bundle.js";
     } else {
       // First file is JS path.
       var stats = require("../dist/server/stats.json");

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -11,6 +11,9 @@
     <![endif]-->
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap-theme.min.css">
+    <style>
+      .output-panel { margin-top: 20px; }
+    </style>
     <title>Converter</title>
   </head>
   <body>

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,0 +1,24 @@
+/**
+ * Webpack development configuration
+ */
+/*globals __dirname:false */
+var path = require("path");
+var webpack = require("webpack");
+var base = require("./webpack.config");
+
+module.exports = {
+  cache: true,
+  context: base.context,
+  entry: base.entry,
+  output: {
+    path: path.join(__dirname, "dist/js"),
+    filename: "bundle.js",
+    publicPath: "http://127.0.0.1:2992/js"
+  },
+  module: base.module,
+  resolve: base.resolve,
+  devtool: "eval-source-map",
+  plugins: [
+    new webpack.NoErrorsPlugin()
+  ]
+};

--- a/webpack.config.hot.js
+++ b/webpack.config.hot.js
@@ -3,8 +3,7 @@
  */
 /*globals __dirname:false */
 var path = require("path");
-var webpack = require("webpack");
-var base = require("./webpack.config");
+var base = require("./webpack.config.dev");
 
 module.exports = {
   cache: true,
@@ -14,11 +13,7 @@ module.exports = {
     "webpack/hot/only-dev-server",
     base.entry
   ],
-  output: {
-    path: path.join(__dirname, "dist/js"),
-    filename: "bundle.hot.js",
-    publicPath: "http://127.0.0.1:2992/js"
-  },
+  output: base.output,
   module: {
     loaders: [
       { test: /\.js(x|)?$/, include: path.join(__dirname, "client"),
@@ -27,7 +22,5 @@ module.exports = {
   },
   resolve: base.resolve,
   devtool: "eval-source-map",
-  plugins: [
-    new webpack.NoErrorsPlugin()
-  ]
+  plugins: base.plugins
 };

--- a/webpack.config.hot.js
+++ b/webpack.config.hot.js
@@ -26,7 +26,7 @@ module.exports = {
     ]
   },
   resolve: base.resolve,
-  devtool: "eval",
+  devtool: "eval-source-map",
   plugins: [
     new webpack.NoErrorsPlugin()
   ]


### PR DESCRIPTION
**NOT DONE STUFF**
- Need to still actually retrieve via AJAX. Looking at `superagent` or `isomorphic-fetch`. (Want to make sure server-side rendering works via localhost loopback even if the current app doesn't normally seed with data / hit that).

Notes:
- Delineate a `npm run dev` vs. `npm run hot` because hot loading has been running far too "hot" on my CPU / laptop battery ;)
- Use Alt for flux implementation.

/cc @kenwheeler @jherr
