### PR TITLE
Flux server-side bootstrap middleware refactor

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -143,7 +143,7 @@ rules:
   max-len: [2, 80, 2]
   max-nested-callbacks: [2, 3]
   max-params: [2, 3]
-  max-statements: [2, 10]
+  max-statements: [2, 15]
   new-cap: 2
   new-parens: 2
   newline-after-var: 0

--- a/client/actions/convert.js
+++ b/client/actions/convert.js
@@ -1,11 +1,9 @@
 /**
  * Actions: Convert
  */
-import alt from "../alt";
 import { fetchConversions } from "../utils/api";
 
-
-class ConvertActions {
+export default class ConvertActions {
   constructor() {
     this.generateActions(
       "updateConversions",
@@ -27,5 +25,3 @@ class ConvertActions {
       });
   }
 }
-
-export default alt.createActions(ConvertActions);

--- a/client/alt.js
+++ b/client/alt.js
@@ -1,6 +1,0 @@
-/**
- * Alt instance.
- */
-import Alt from "alt";
-
-export default new Alt();

--- a/client/app.jsx
+++ b/client/app.jsx
@@ -5,10 +5,15 @@
 import React from "react";
 import Page from "./components/page";
 
-import alt from "./alt";
+import Flux from "./flux";
 import { parseBootstrap } from "./utils/query";
 
 const rootEl = document.querySelector(".js-content");
+
+// Although our Flux store is not a singleton, from the point of view of the
+// client-side application, we instantiate a single instance here which the
+// entire app will share. (So the client app _has_ an effective singleton).
+const flux = new Flux();
 
 // Try server bootstrap _first_ because doesn't need a fetch.
 const serverBootstrapEl = document.querySelector(".js-bootstrap");
@@ -16,7 +21,7 @@ let serverBootstrap;
 if (serverBootstrapEl) {
   try {
     serverBootstrap = JSON.parse(serverBootstrapEl.innerHTML);
-    alt.bootstrap(JSON.stringify(serverBootstrap));
+    flux.bootstrap(JSON.stringify(serverBootstrap));
   } catch (err) {
     // Ignore error.
   }
@@ -27,10 +32,10 @@ if (!serverBootstrap) {
   const clientBootstrap = parseBootstrap(location.search);
 
   if (clientBootstrap) {
-    alt.bootstrap(JSON.stringify({
+    flux.bootstrap(JSON.stringify({
       ConvertStore: clientBootstrap
     }));
-    alt.getActions("ConvertActions").fetchConversions(
+    flux.getActions("ConvertActions").fetchConversions(
       clientBootstrap.types,
       clientBootstrap.value
     );
@@ -38,4 +43,4 @@ if (!serverBootstrap) {
 }
 
 // Note: Change suffix to `.js` if not using actual JSX.
-React.render(<Page />, rootEl);
+React.render(<Page flux={flux} />, rootEl);

--- a/client/components/page.jsx
+++ b/client/components/page.jsx
@@ -10,17 +10,18 @@ import Types from "./types";
 import Output from "./output";
 
 import AltContainer from "alt/AltContainer";
-import ConvertStore from "../stores/convert";
 
 // Helper for adding stores.
-const addStore = (component) => (
-  <AltContainer store={ConvertStore}>
+const addStore = (component, store) => (
+  <AltContainer store={store}>
     {component}
   </AltContainer>
 );
 
 export default class Page extends React.Component {
    render() {
+    const store = this.props.flux.getStore("ConvertStore");
+
     return (
       <div className="container">
         <Jumbotron>
@@ -28,12 +29,16 @@ export default class Page extends React.Component {
           <p>Camel, snake and dasherize to awesomeness!</p>
         </Jumbotron>
         <div className="input-group">
-          {addStore(<Convert />)}
-          {addStore(<Input />)}
-          {addStore(<Types />)}
+          {addStore(<Convert />, store)}
+          {addStore(<Input />, store)}
+          {addStore(<Types />, store)}
         </div>
-        {addStore(<Output />)}
+        {addStore(<Output />, store)}
       </div>
     );
   };
 }
+
+Page.propTypes = {
+  flux: React.PropTypes.object.isRequired
+};

--- a/client/components/types.jsx
+++ b/client/components/types.jsx
@@ -10,7 +10,7 @@ import types from "../utils/types";
 
 import ConvertActions from "../actions/convert";
 
-const noop = function () {};
+const noop = () => {};
 
 export default class Types extends React.Component {
   setTypes(conversionTypes) {

--- a/client/flux.js
+++ b/client/flux.js
@@ -1,0 +1,16 @@
+/**
+ * Alt instance.
+ */
+import Alt from "alt";
+
+import ConvertActions from "./actions/convert";
+import ConvertStore from "./stores/convert";
+
+export default class Flux extends Alt {
+  constructor(config = {}) {
+    super(config);
+
+    this.addActions("ConvertActions", ConvertActions);
+    this.addStore("ConvertStore", ConvertStore);
+  }
+}

--- a/client/stores/convert.js
+++ b/client/stores/convert.js
@@ -1,16 +1,13 @@
 /**
  * Stores: Convert
  */
-import alt from "../alt";
-import ConvertActions from "../actions/convert";
-
 import types from "../utils/types";
 
-class ConvertStore {
+export default class ConvertStore {
   constructor() {
     // Auto-magically bind to methods with `onACTION` or `ACTION`.
     // See: http://alt.js.org/docs/createStore/#storemodelbindactions
-    this.bindActions(ConvertActions);
+    this.bindActions(this.alt.getActions("ConvertActions"));
 
     // TODO: Switch to immutable-js + alt integration.
     this.conversions = [];
@@ -42,5 +39,3 @@ class ConvertStore {
     this.conversionError = err.message || err.toString();
   }
 }
-
-export default alt.createStore(ConvertStore, "ConvertStore");

--- a/server/index.js
+++ b/server/index.js
@@ -57,7 +57,19 @@ var Page = React.createFactory(require("../client/components/page"));
 var Flux = require("../client/flux");
 
 app.indexRoute = function (root) {
-  app.use(root, [mid.flux.actions(Page)], function (req, res) {
+  // --------------------------------------------------------------------------
+  // Middleware choice!
+  // --------------------------------------------------------------------------
+  //
+  // We support two different flux bootstrap data/component middlewares, that
+  // can be set like:
+  //
+  // var fluxMiddleware = mid.flux.fetch(Page);   // Fetch manually
+  // var fluxMiddleware = mid.flux.actions(Page); // Instance actions.
+  //
+  var fluxMiddleware = mid.flux.actions(Page); // Instance actions.
+
+  app.use(root, [fluxMiddleware], function (req, res) {
     // Render JS? Server-side? Bootstrap?
     var mode = req.query.__mode;
     var renderJs = RENDER_JS && mode !== "nojs";

--- a/server/index.js
+++ b/server/index.js
@@ -94,6 +94,6 @@ app.indexRoute = function (root) {
 // Actually start server if script.
 /* istanbul ignore next */
 if (require.main === module) {
-  app.indexRoute("/");
+  app.indexRoute(/^\/$/);
   app.listen(PORT);
 }

--- a/server/index.js
+++ b/server/index.js
@@ -54,9 +54,10 @@ app.get("/api/dash", function (req, res) {
 // Client-side imports
 var React = require("react");
 var Page = React.createFactory(require("../client/components/page"));
+var Flux = require("../client/flux");
 
 app.indexRoute = function (root) {
-  app.use(root, [mid.flux.fetchFirst(Page)], function (req, res) {
+  app.use(root, [mid.flux.actions(Page)], function (req, res) {
     // Render JS? Server-side? Bootstrap?
     var mode = req.query.__mode;
     var renderJs = RENDER_JS && mode !== "nojs";
@@ -74,6 +75,14 @@ app.indexRoute = function (root) {
       }
     }
 
+    // Server-rendered page.
+    var content;
+    if (renderSs) {
+      content = res.locals.bootstrapComponent ||
+        React.renderToString(new Page({ flux: new Flux() }));
+    }
+
+    // Response.
     res.render("index.hbs", {
       layout: false,
       bootstrap: res.locals.bootstrapData,
@@ -83,10 +92,7 @@ app.indexRoute = function (root) {
       bundles: {
         js: bundleJs
       },
-      content: renderSs ?
-        // Try bootstraped page _first_ if we created it.
-        res.locals.bootstrapComponent || React.renderToString(new Page()) :
-        null
+      content: content
     });
   });
 };

--- a/server/middleware.js
+++ b/server/middleware.js
@@ -149,9 +149,9 @@ module.exports.flux = {
       // Flux instance for this single request / callback.
       var flux = new Flux();
       var listener = new ActionListeners(flux);
-      var actions = flux.actions.ConvertActions;
+      var actions = flux.getActions("ConvertActions");
 
-      // Wrap
+      // Wrap cleanup methods.
       var _done = function (err) {
         listener.removeAllActionListeners();
         flux.flush();

--- a/server/middleware.js
+++ b/server/middleware.js
@@ -10,9 +10,6 @@
  * - `bootstrapComponent`: Rendered component for app.
  */
 var React = require("react");
-var alt = require("../client/alt");
-
-var fetchConversions = require("../client/utils/api").fetchConversions;
 
 // Return query bootstrap information or `null`.
 var _getQueryBootstrap = function (req) {
@@ -48,6 +45,10 @@ module.exports.flux = {
       if (!queryBootstrap) { return next(); }
       var types = queryBootstrap.types;
       var value = queryBootstrap.value;
+
+      // TODO: FIX
+      var alt = require("../client/alt");
+      var fetchConversions = require("../client/utils/api").fetchConversions;
 
       // Fetch from localhost.
       fetchConversions(types, value)

--- a/server/middleware.js
+++ b/server/middleware.js
@@ -8,6 +8,12 @@
  *
  * - `bootstrapData`: Data bootstrap for the app.
  * - `bootstrapComponent`: Rendered component for app.
+ *
+ * Strategies so far:
+ *
+ * - `fetch`: Manually retrieve data and send through singleton flux.
+ * - `actions`: Use flux instances to invoke/listen to actions and get data.
+ *
  */
 var React = require("react");
 var Flux = require("../client/flux");
@@ -38,6 +44,17 @@ module.exports.flux = {
    *
    * Use the underlying API to fetch data and then manually `bootstrap`.
    *
+   * The advantages of this approach are:
+   *
+   * - It doesn't add extra listeners, instead going straight to the source.
+   * - More efficient with a singleton flux instance.
+   *
+   * The disadvantages of this approach are:
+   *
+   * - There is separate logic for retrieving data on the server vs. the client.
+   * - All flux interaction has to be `synchronous` because it's a singleton.
+   *   (But that part can be easily changed).
+   *
    * **Flux Singleton**: This middleware uses a single flux instance across
    * all requests, which means that our sequence of:
    *
@@ -52,7 +69,7 @@ module.exports.flux = {
    * @param   {Object}    Component React component to render.
    * @returns {Function}            middleware function
    */
-  fetchFirst: function (Component) {
+  fetch: function (Component) {
     // Flux singleton for atomic actions.
     var flux = new Flux();
 
@@ -99,8 +116,24 @@ module.exports.flux = {
    *
    * Use store actions and listeners to inflate the store.
    *
+   * The advantages of this approach are:
+   *
+   * - Uses the _exact same_ series of actions to inflate store as client.
+   *
+   * The disadvantages of this approach are:
+   *
+   * - Adds extra listeners in a slightly complicated way.
+   * - Cannot use flux singletons.
+   *
    * **Flux Instance**: This middleware creates ephemeral flux instances to
    * allow async actions free reign to mutate store state before snapshotting.
+   * The work sequence is:
+   *
+   * - Create new `flux` instance.
+   * - Set `ActionListeners` on appropriate events.
+   * - Invoke the necessary action(s) to inflate the store.
+   * - Snapshot the store data.
+   * - Clean up the flux instance, listeners, etc.
    *
    * @param   {Object}    Component React component to render.
    * @returns {Function}            middleware function

--- a/server/middleware.js
+++ b/server/middleware.js
@@ -158,6 +158,9 @@ module.exports.flux = {
         next(err);
       };
 
+      // ----------------------------------------------------------------------
+      // Listeners
+      // ----------------------------------------------------------------------
       // **Strategy**: Execute a series of Flux Actions that end with the
       // correct data store results we can snapshot.
       //
@@ -180,7 +183,17 @@ module.exports.flux = {
       // Error-handling.
       listener.addActionListener(actions.CONVERSION_ERROR, _done);
 
-      // Invoke fetching actions.
+      // ----------------------------------------------------------------------
+      // Actions
+      // ----------------------------------------------------------------------
+      // The rub here is that we have to remember and invoke _all_ of the
+      // actions that will leave us in the proper state.
+
+      // Invoke sync actions.
+      actions.setConversionTypes(types);
+      actions.setConversionValue(value);
+
+      // Invoke async actions.
       actions.fetchConversions(types, value);
     };
   }

--- a/server/middleware.js
+++ b/server/middleware.js
@@ -33,9 +33,20 @@ var _getQueryBootstrap = function (req) {
 
 module.exports.flux = {
   /**
-   * "Fetch first" strategy middleware.
+   * "Fetch first" strategy middleware with **singleton**.
    *
    * Use the underlying API to fetch data and then manually `bootstrap`.
+   *
+   * **Flux Singleton**: This middleware uses a single flux instance across
+   * all requests, which means that our sequence of:
+   *
+   * - `alt.bootstrap(DATA)`
+   * - `alt.takeSnapshot()`
+   * - React component render
+   * - `alt.flush()`
+   *
+   * Has to be synchronous and complete in the immediate thread before handing
+   * control back to another event.
    *
    * @param   {Object}    Component React component to render.
    * @returns {Function}            middleware function


### PR DESCRIPTION
This PR ends us with two separate middlewares to do flux data / component bootstraps via:
- `flux.fetch`: Manually retrieve data and send through singleton flux.
- `flux.actions`: Use flux instances to invoke/listen to actions and get data.

to allow for further taste tests about the different approaches. Also, I refactored the underlying Alt subclass to be instantiable. That said, I left the client _using_ a single instance of the Alt subclass.

@kenwheeler @goatslacker -- Any comments / thoughts on the two middleware patterns I have are most welcome if you have a moment!
