### PR TITLE
BUG: Fix missing CSS, broken client bootstrap renders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ URLS to test things out:
   server-side. Note that while some links may work (e.g. clicking on a note
   title in list), many things do not since there are absolutely no JS libraries.
   This is intended to just be a small demo of SEO / "crawlable" content.
+  This mode is incompatible with the React hot loader mode because in hot mode
+  JS is used to load CSS. If you want to run a development server while using
+  `nojs`, use `npm run dev`.
 
 ### Bootstrapped Data
 

--- a/client/app.jsx
+++ b/client/app.jsx
@@ -6,6 +6,7 @@ import React from "react";
 import Page from "./components/page";
 
 import Flux from "./flux";
+import ActionListeners from "alt/utils/ActionListeners";
 import { parseBootstrap } from "./utils/query";
 
 const rootEl = document.querySelector(".js-content");
@@ -14,6 +15,10 @@ const rootEl = document.querySelector(".js-content");
 // client-side application, we instantiate a single instance here which the
 // entire app will share. (So the client app _has_ an effective singleton).
 const flux = new Flux();
+
+// Render helpers -- may defer based on client-side actions.
+let deferRender = false;
+const render = () => { React.render(<Page flux={flux} />, rootEl); };
 
 // Try server bootstrap _first_ because doesn't need a fetch.
 const serverBootstrapEl = document.querySelector(".js-bootstrap");
@@ -32,15 +37,36 @@ if (!serverBootstrap) {
   const clientBootstrap = parseBootstrap(location.search);
 
   if (clientBootstrap) {
+    // Bootstrap.
     flux.bootstrap(JSON.stringify({
       ConvertStore: clientBootstrap
     }));
-    flux.getActions("ConvertActions").fetchConversions(
+
+    // Set up listeners to render.
+    // Need the update conversions to **fully complete** to be consistent for
+    // the rendering.
+    deferRender = true;
+    const actions = flux.getActions("ConvertActions");
+    const listener = new ActionListeners(flux);
+    const _done = () => {
+      // Render
+      render();
+
+      // Remove all of the listeners for our custom action listener.
+      listener.removeAllActionListeners();
+    };
+    listener.addActionListener(actions.UPDATE_CONVERSIONS, _done);
+    listener.addActionListener(actions.CONVERSION_ERROR, _done);
+
+    // Trigger fetch.
+    actions.fetchConversions(
       clientBootstrap.types,
       clientBootstrap.value
     );
   }
 }
 
-// Note: Change suffix to `.js` if not using actual JSX.
-React.render(<Page flux={flux} />, rootEl);
+// Do a straight render.
+if (!deferRender) {
+  render();
+}

--- a/server/index.js
+++ b/server/index.js
@@ -89,24 +89,21 @@ app.indexRoute = function (root) {
     var renderJs = RENDER_JS && mode !== "nojs";
     var renderSs = RENDER_SS && mode !== "noss";
 
-    // JS bundle rendering.
+    // JS/CSS bundle rendering.
     var bundleJs;
     var bundleCss;
-    if (renderJs) {
-      if (WEBPACK_TEST_BUNDLE) {
-        bundleJs = WEBPACK_TEST_BUNDLE;
-        bundleCss = "http://127.0.0.1:2992/js/style.css";
-      } else if (WEBPACK_HOT) {
-        bundleJs = "http://127.0.0.1:2992/js/bundle.js";
-      } else if (WEBPACK_DEV) {
-        bundleJs = "http://127.0.0.1:2992/js/bundle.js";
-        bundleCss = "http://127.0.0.1:2992/js/style.css";
-      } else {
-        // First file is JS path.
-        var stats = require("../dist/server/stats.json");
-        bundleJs = path.join("/js", stats.assetsByChunkName.main[0]);
-        bundleCss = path.join("/js", stats.assetsByChunkName.main[1]);
-      }
+    if (WEBPACK_TEST_BUNDLE) {
+      bundleJs = renderJs ? WEBPACK_TEST_BUNDLE : null;
+      bundleCss = "http://127.0.0.1:2992/js/style.css";
+    } else if (WEBPACK_HOT || WEBPACK_DEV) {
+      bundleJs = renderJs ? "http://127.0.0.1:2992/js/bundle.js" : null;
+      // TODO(ALEX): What's hot vs. dev difference?
+      bundleCss = "http://127.0.0.1:2992/js/style.css";
+    } else {
+      // First file is JS path.
+      var stats = require("../dist/server/stats.json");
+      bundleJs = path.join("/js", stats.assetsByChunkName.main[0]);
+      bundleCss = path.join("/js", stats.assetsByChunkName.main[1]);
     }
 
     // Server-rendered client component.

--- a/server/index.js
+++ b/server/index.js
@@ -90,15 +90,20 @@ app.indexRoute = function (root) {
     var renderSs = RENDER_SS && mode !== "noss";
 
     // JS/CSS bundle rendering.
+    var devBundleJsUrl = "http://127.0.0.1:2992/js/bundle.js";
+    var devBundleCssUrl = "http://127.0.0.1:2992/js/style.css";
     var bundleJs;
     var bundleCss;
+
     if (WEBPACK_TEST_BUNDLE) {
       bundleJs = renderJs ? WEBPACK_TEST_BUNDLE : null;
-      bundleCss = "http://127.0.0.1:2992/js/style.css";
-    } else if (WEBPACK_HOT || WEBPACK_DEV) {
-      bundleJs = renderJs ? "http://127.0.0.1:2992/js/bundle.js" : null;
-      // TODO(ALEX): What's hot vs. dev difference?
-      bundleCss = "http://127.0.0.1:2992/js/style.css";
+      bundleCss = devBundleCssUrl;
+    } else if (WEBPACK_HOT) {
+      // In hot mode, there is no CSS file because styles are inlined in a <style> tag
+      bundleJs = renderJs ? devBundleJsUrl : null;
+    } else if (WEBPACK_DEV) {
+      bundleJs = renderJs ? devBundleJsUrl : null;
+      bundleCss = devBundleCssUrl;
     } else {
       // First file is JS path.
       var stats = require("../dist/server/stats.json");


### PR DESCRIPTION
This PR makes all URLs in the README.md work.
- Fixes missing CSS for `127.0.0.1:3000/?__mode=nojs`
- Moves clientside data bootstrap app `render` call _after_ the backend server conversions call.

@alexlande @kenwheeler -- Feel free to just take over, discuss, modify and merge this PR as you see fit. My main goal is to get all of the README.md URLs actually working again. Some random notes:
- The client-side-only data bootstrap takes partial store parameters but still does a bootstrap fetch to the backend for the conversions. We have to delay the initial render call to get the flux store in the proper state. But, instead we could inflate the full server-created data bootstrap instead. Meaning not handling "fetch is initiated state" could be consider an application programming error / bug in it's own right.
- Some of this will be obviated by @kenwheeler 's Redux PR, so maybe just do whatever to get `master` working and use that as a baseline verify for what the Redux PR will need to do.

Thanks!
